### PR TITLE
Cleanup opengraph + twitter cards

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,7 +1,7 @@
 languageCode = "en-us"
 title = "Jonathan Keane Photography"
-# If specified, it messes up some links on the preview site, is it needed at all?
-# baseURL = "https://photo.jonkeane.com"
+# Supposedly: if specified, it messes up some links on the preview site, is it needed at all?
+baseURL = "https://photo.jonkeane.com"
 theme = "hugo-theme-massively-jtk"
 googleanalytics = "G-CPQDC0642Z"
 # disableKinds = ["taxonomy", "taxonomyTerm", "section"]


### PR DESCRIPTION
The galleries now have their own opengraph images — individual image "pages" unfortunately cannot since opengraph parsers use the HTML DOM prior to any JS manipulation (e.g. nanogallery doing its thing)