### PR TITLE
Support open graph image replacements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ blogdown
 .DS_Store
 public/
 resources/
+# Local Netlify folder
+.netlify

--- a/config.toml
+++ b/config.toml
@@ -49,8 +49,7 @@ sectionPagesMenu = "main"
 [params.nanog]
   flickr_userid = "65556368@N00"
   # flickr_userid = "jonkeane"
-  # this doesn't actually make the label appear since it's set to display off
-  # thumbnailHoverEffect2 = "imageScale105"
+  thumbnailHoverEffect2 = "imageScale105"
   tagBlockList = "nogallery"
 
 [params.slider]

--- a/config.toml
+++ b/config.toml
@@ -50,7 +50,7 @@ sectionPagesMenu = "main"
   flickr_userid = "65556368@N00"
   # flickr_userid = "jonkeane"
   # this doesn't actually make the label appear since it's set to display off
-  thumbnailHoverEffect2 = "imageScale105"
+  # thumbnailHoverEffect2 = "imageScale105"
   tagBlockList = "nogallery"
 
 [params.slider]

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,5 +5,6 @@ HUGO_VERSION = "0.110.0"
 HUGO_VERSION = "0.110.0"
 
 [[edge_functions]]
-path = "/gallery/*"
+path = "/gallery/*/*"
+excludedPath = "/*.jpg"
 function = "og-image"

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,3 +3,7 @@ HUGO_VERSION = "0.110.0"
 
 [context.deploy-preview.environment]
 HUGO_VERSION = "0.110.0"
+
+[[edge_functions]]
+path = "/gallery/*"
+function = "og-image"

--- a/netlify/edge-functions/og-image.js
+++ b/netlify/edge-functions/og-image.js
@@ -1,18 +1,18 @@
 export default async (request, context) => {
     const url = new URL(request.url)
-    
+
     // Get the page content.
     const response = await context.next()
     const page = await response.text()
-    
+
     // Only run if the s query parameter is set
-    if (!url.searchParams.has("s")) {
+    if (!url.searchParams.has("og")) {
         return;
     }
 
     const regex = /(<meta property="og:image" content=")(.*)(" \/>)/g;
-    // Replace it with the path plus the querystring.
-    const replace = "$1https://live.staticflickr.com/" + url.searchParams.get('s') + "$3";
+    // Replace it with the base  plus the querystring.
+    const replace = "$1https://live.staticflickr.com/" + url.searchParams.get("og") + "$3";
     console.log(replace)
     return new Response(page.replaceAll(regex, replace), response);
 }

--- a/netlify/edge-functions/og-image.js
+++ b/netlify/edge-functions/og-image.js
@@ -1,0 +1,14 @@
+export default async (request, context) => {
+    const url = new URL(request.url)
+    
+    // Get the page content.
+    const response = await context.next()
+    const page = await response.text()
+    
+    // Look for the OG image generator path.
+    const search = 'static_og'
+    // Replace it with the path plus the querystring.
+    const replace = 'https://live.staticflickr.com/' + url.searchParams.get('s')
+
+    return new Response(page.replaceAll(search, replace), response);
+}

--- a/netlify/edge-functions/og-image.js
+++ b/netlify/edge-functions/og-image.js
@@ -5,10 +5,14 @@ export default async (request, context) => {
     const response = await context.next()
     const page = await response.text()
     
-    // Look for the OG image generator path.
-    const search = 'static_og'
-    // Replace it with the path plus the querystring.
-    const replace = 'https://live.staticflickr.com/' + url.searchParams.get('s')
+    // Only run if the s query parameter is set
+    if (!url.searchParams.has("s")) {
+        return;
+    }
 
-    return new Response(page.replaceAll(search, replace), response);
+    const regex = /(<meta property="og:image" content=")(.*)(" \/>)/g;
+    // Replace it with the path plus the querystring.
+    const replace = "$1https://live.staticflickr.com/" + url.searchParams.get('s') + "$3";
+    console.log(replace)
+    return new Response(page.replaceAll(regex, replace), response);
 }


### PR DESCRIPTION
This includes:

* nanogallery updates that pass open graph as query paramters
* netlify edge function that re-writes the og:image to have the url from flickr
* make the slugs smaller so URL shares are slightly shorter and less repetitive  